### PR TITLE
docs: clarify auth-profiles limitation + atomic config write

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ Currently working with API keys and general secrets. oAuth Credential Migration 
 
 ### ⚠️ Important Limitation
 
-**OpenClaw's `auth-profiles.json` does not support environment variable substitution.** OAuth tokens will break if migrated to `${ENV_VAR}` format because OpenClaw parses them as JWTs.
+**OpenClaw's `auth-profiles.json` does not support environment variable substitution.** `${ENV_VAR}` placeholders are treated as literal strings.
+
+- This means `clawvault openclaw migrate --apply` will rewrite `auth-profiles.json` into a format OpenClaw cannot use (authentication will fail).
+- **OAuth is especially brittle:** placeholder strings may be validated/parsed as tokens before any future expansion.
+
+**Recommendation:** use `clawvault openclaw migrate` as a **dry-run scanner only** until OpenClaw supports env-var substitution (or ClawVault gains a supported runtime integration path).
 
 **Current status:** Plaintext credentials with filesystem permissions (0600) for single-user deployments. See [ROADMAP.md](ROADMAP.md) for upstream issue tracking and planned eCryptfs alternative.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -121,7 +121,9 @@ clawvault request OPENAI_API_KEY \
 
 ### `openclaw migrate`
 
-Migrate plaintext secrets from auth-profiles.json to encrypted storage.
+Migrate plaintext secrets from auth-profiles.json to encrypted storage (**experimental**).
+
+⚠️ **Important:** OpenClaw does not currently expand `${ENV_VAR}` placeholders in `auth-profiles.json`. Using `--apply` will rewrite the file into a format OpenClaw cannot use. Prefer dry-run mode until upstream support exists.
 
 ```bash
 # Dry-run (safe, shows what will migrate)


### PR DESCRIPTION
Proactive agent review:\n- Added critical warning about OpenClaw  expansion limitation\n- Updated CLI and MIGRATION docs with experimental flags\n- Fixed atomic write for config to prevent partial reads\n\nReviewed by: coder (MiniMax)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that environment variable placeholders are treated as literal strings during migration
  * Added safety warnings about potential data issues when using migration apply operations
  * Introduced recommended dry-run workflow for migration discovery until full support is available
  * Labeled migration feature as experimental

* **Bug Fixes**
  * Enhanced configuration file persistence with atomic write operations to prevent data corruption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->